### PR TITLE
feat: add workflow documentation

### DIFF
--- a/docs/adr-001-packaging-approach.md
+++ b/docs/adr-001-packaging-approach.md
@@ -1,0 +1,68 @@
+# ADR-001: Packaging Approach for Azlan GitHub Workflow
+
+**Status**: Accepted
+**Date**: 2026-02-12
+**Epic**: Epic 9K (#155)
+
+## Context
+
+The Azlan workflow (Epic/Feature/Story/PBS/WBS hierarchy, naming conventions, label taxonomy, project board fields) was developed and proven in the `Azlan-EA-AAA` repository. Sibling projects need to adopt the same conventions without copying files manually or reinventing configuration.
+
+## Decision
+
+Package the workflow as **three complementary layers**:
+
+### Layer 1: GitHub Template Repository
+- `.github/ISSUE_TEMPLATE/` — issue forms (epic, feature, story, PBS, WBS)
+- `.github/pull_request_template.md` — PR template with registry traceability
+- `.github/labels.yml` — label definitions
+- `.github/workflows/` — enforcement workflows
+
+**Rationale**: Templates are the simplest adoption path. A new repo created from the template gets everything pre-configured with zero commands.
+
+### Layer 2: Idempotent Setup Scripts
+- `scripts/setup-labels.sh` — create labels via `gh` CLI
+- `scripts/setup-branch-protection.sh` — configure main branch rules
+- `scripts/setup-gh-project.sh` — create project board with standard fields
+- `scripts/migrate-issues-into-hierarchy.sh` — classify existing issues
+- `scripts/setup-all.sh` — orchestrate all scripts
+
+**Rationale**: Existing repos can't use templates retroactively. Scripts provide the same result for repos that already exist. Idempotency means they're safe to re-run.
+
+### Layer 3: Claude Code Plugin
+- `azlan-github-workflow/` — plugin with 6 skills
+- Skills: setup-repo, create-epic, create-feature, create-story, setup-project-board, review-hierarchy
+
+**Rationale**: Claude Code users get intelligent, convention-aware commands that auto-detect numbering, validate naming, and audit compliance. Non-Claude users lose nothing — Layers 1 and 2 work independently.
+
+## Alternatives Considered
+
+| Alternative | Why Not |
+|-------------|---------|
+| **Monorepo only** | Forces all projects into one repo; doesn't scale to independent repos |
+| **GitHub Actions reusable workflows only** | Good for enforcement but can't create labels, project boards, or issue templates |
+| **MCP server instead of skills** | Over-engineered for this use case; skills are simpler and don't require a running server |
+| **npm/pip package** | Adds a package manager dependency; `gh` CLI is sufficient |
+
+## Conventions: Mandatory vs Recommended
+
+### Mandatory
+- Title format: `Epic N:`, `FN.x:`, `SN.x.y:`, `[PBS]`, `[WBS]`
+- Labels: `type:epic`, `type:feature`, `type:story`, `type:pbs`, `type:wbs`
+- PR traceability: `Resolves: #N` for all PRs
+- Registry artifact: Required on WBS/PBS PRs
+
+### Recommended
+- Project-specific labels (e.g., `visualiser`)
+- Domain labels (`domain:*`)
+- Tier labels (`tier:*`)
+- Phase labels (`phase:*`)
+- Project board with standard fields
+
+## Consequences
+
+- **Positive**: Any repo can adopt in under 15 minutes via any of the three paths
+- **Positive**: No runtime dependencies beyond `gh` CLI
+- **Positive**: Claude Code users get convention-aware intelligence
+- **Negative**: Plugin requires Claude Code — but Layer 1+2 work without it
+- **Negative**: Three layers means three things to maintain — mitigated by the fact that they share conventions, not code

--- a/docs/migration-checklist.md
+++ b/docs/migration-checklist.md
@@ -1,0 +1,66 @@
+# Azlan Workflow — Migration Checklist
+
+Use this checklist when retrofitting the Azlan workflow onto an existing repository.
+
+## Prerequisites
+
+- [ ] `gh` CLI installed and authenticated (`gh auth status`)
+- [ ] Repository admin access
+- [ ] Current branch is up to date with `main`
+
+## Step 1: Labels
+
+- [ ] Run `./scripts/setup-labels.sh --repo OWNER/REPO`
+- [ ] Verify labels visible at `https://github.com/OWNER/REPO/labels`
+- [ ] Verify hierarchy labels: `type:epic`, `type:feature`, `type:story`, `type:pbs`, `type:wbs`, `type:registry`
+- [ ] Add any project-specific labels manually (e.g., `visualiser`)
+
+## Step 2: Issue Templates
+
+- [ ] Copy `.github/ISSUE_TEMPLATE/` to your repo
+- [ ] Copy `.github/ISSUE_TEMPLATE/config.yml` (disables blank issues)
+- [ ] Verify templates appear at `https://github.com/OWNER/REPO/issues/new/choose`
+
+## Step 3: PR Template
+
+- [ ] Copy `.github/pull_request_template.md` to your repo
+- [ ] Verify template appears when creating a new PR
+
+## Step 4: Enforcement Workflows
+
+- [ ] Copy `.github/workflows/enforce-registry-link.yml`
+- [ ] Copy `.github/workflows/validate-issue-naming.yml`
+- [ ] Copy `.github/workflows/validate-labels.yml`
+- [ ] Push to `main` and verify workflows appear in Actions tab
+
+## Step 5: Branch Protection
+
+- [ ] Run `./scripts/setup-branch-protection.sh --repo OWNER/REPO --mode solo`
+- [ ] Verify: `git push --force origin main` should be rejected
+- [ ] For team repos: use `--mode team` instead
+
+## Step 6: Project Board
+
+- [ ] Run `./scripts/setup-gh-project.sh --owner OWNER --project-title "Project Name" --repo OWNER/REPO`
+- [ ] Verify project has 7 standard fields (Type, Status, Priority, Estimate, Registry ID, PBS ID, WBS Code)
+- [ ] Verify repo is linked to project
+
+## Step 7: Classify Existing Issues
+
+- [ ] Preview: `./scripts/migrate-issues-into-hierarchy.sh --repo OWNER/REPO --dry-run`
+- [ ] Review output — check for false positives
+- [ ] Apply: `./scripts/migrate-issues-into-hierarchy.sh --repo OWNER/REPO`
+- [ ] Manually fix any issues that weren't auto-classified
+
+## Step 8: Plugin (Optional)
+
+- [ ] Install: `claude --plugin-dir /path/to/azlan-github-workflow`
+- [ ] Test: `/azlan-github-workflow:review-hierarchy OWNER/REPO`
+- [ ] Fix any compliance issues flagged by the audit
+
+## Verification
+
+- [ ] Create a test epic using the issue template form
+- [ ] Create a test feature linked to the epic
+- [ ] Create a PR referencing a WBS issue — verify registry enforcement fires
+- [ ] Run `/azlan-github-workflow:review-hierarchy` — all checks pass

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,146 @@
+# Azlan Workflow — Onboarding Guide
+
+This guide covers three adoption paths for the Azlan GitHub workflow.
+
+## Prerequisites
+
+- [GitHub CLI (`gh`)](https://cli.github.com/) installed and authenticated
+- Repository admin access
+- (Optional) [Claude Code](https://claude.com/claude-code) for plugin skills
+
+---
+
+## Path 1: New Repository (one command)
+
+### Interactive Bootstrap (recommended)
+
+Run this directly in your **terminal** (requires a TTY for the prompts):
+
+```bash
+gh api repos/ajrmooreuk/Azlan-EA-AAA/contents/scripts/bootstrap-new-repo.sh \
+  -q '.content' | base64 -d | bash -s --
+```
+
+The wizard prompts you for:
+
+- **Repository name**
+- **Project board title** (defaults to repo name)
+- **Visibility** — public or private
+- **Branch protection** — solo (PRs optional) or team (PRs required)
+- **Claude Code plugin** — yes or no
+
+It then creates the repo, downloads all templates/workflows/scripts, pushes to main, creates labels, configures branch protection, and sets up a project board.
+
+> **Note:** Interactive mode requires a real terminal. It reads input from `/dev/tty`, so it works even when the script itself is piped in — but it will **not** work inside CI pipelines, Docker builds, or non-interactive tool runners (e.g. Claude Code). Use the non-interactive form below for those environments.
+
+### Non-interactive Bootstrap
+
+Pass all options as arguments — no TTY needed, suitable for scripts and CI:
+
+```bash
+gh api repos/ajrmooreuk/Azlan-EA-AAA/contents/scripts/bootstrap-new-repo.sh \
+  -q '.content' | base64 -d | bash -s -- my-new-repo
+```
+
+### Options (non-interactive mode)
+
+```bash
+# With Claude Code plugin
+... | bash -s -- my-new-repo --with-plugin
+
+# Private repo, team-level protection
+... | bash -s -- my-new-repo --private --mode team
+
+# Custom project board name
+... | bash -s -- my-new-repo --project-title "My Project"
+```
+
+### Launch the Claude Code plugin (if installed with `--with-plugin`)
+```bash
+cd my-new-repo
+claude --plugin-dir ./azlan-github-workflow
+```
+
+Now you can use `/azlan-github-workflow:create-epic`, `/azlan-github-workflow:create-feature`, etc.
+
+---
+
+## Path 2: Existing Repository
+
+### Step 1 — Copy workflow files
+Copy these directories from the template into your repo:
+```
+.github/ISSUE_TEMPLATE/   → issue form templates
+.github/pull_request_template.md
+.github/workflows/        → enforcement workflows
+scripts/                  → setup & migration scripts
+```
+
+### Step 2 — Run setup scripts
+```bash
+# Create standard labels
+./scripts/setup-labels.sh --repo OWNER/my-repo
+
+# Configure branch protection
+./scripts/setup-branch-protection.sh --repo OWNER/my-repo --mode solo
+
+# Create project board
+./scripts/setup-gh-project.sh --owner OWNER --project-title "My Project" --repo OWNER/my-repo
+```
+
+### Step 3 — Migrate existing issues
+Preview what would change:
+```bash
+./scripts/migrate-issues-into-hierarchy.sh --repo OWNER/my-repo --dry-run
+```
+
+Apply labels:
+```bash
+./scripts/migrate-issues-into-hierarchy.sh --repo OWNER/my-repo
+```
+
+### Step 4 — Install the Claude Code plugin (optional)
+```bash
+claude --plugin-dir /path/to/azlan-github-workflow
+```
+
+---
+
+## Path 3: Without Claude Code
+
+Everything works without the plugin. The plugin just provides convenience commands.
+
+| Task | Without Plugin | With Plugin |
+|------|---------------|-------------|
+| Create epic | Use issue template form on GitHub | `/azlan-github-workflow:create-epic` |
+| Create feature | Use issue template form on GitHub | `/azlan-github-workflow:create-feature` |
+| Setup repo | `./scripts/setup-all.sh` | `/azlan-github-workflow:setup-repo` |
+| Audit compliance | Manual review | `/azlan-github-workflow:review-hierarchy` |
+
+The issue templates, PR template, enforcement workflows, and setup scripts all work independently.
+
+---
+
+## Naming Convention Quick Reference
+
+| Type | Format | Example |
+|------|--------|---------|
+| Epic | `Epic N:` | `Epic 10: Customer Onboarding` |
+| Feature | `FN.x:` | `F10.1: Registration Flow` |
+| Story | `SN.x.y:` | `S10.1.1: Email Validation` |
+| PBS | `[PBS]` | `[PBS] Auth Module` |
+| WBS | `[WBS]` | `[WBS] Implement OAuth Endpoint` |
+
+Letter suffixes for sub-epics: `Epic 9K:` → `F9K.1:` → `S9K.1.1:`
+
+---
+
+## What's Enforced Automatically
+
+| Workflow | Trigger | What It Checks |
+|----------|---------|---------------|
+| `enforce-registry-link.yml` | PR open/edit | WBS/PBS PRs must have `Registry Artifact:` |
+| `validate-issue-naming.yml` | Issue open/edit | Title matches label convention |
+| `validate-labels.yml` | Issue open/edit/label | Title implies type but label is missing |
+
+All enforcement is non-blocking (warnings) except the registry link check which fails the PR.

--- a/docs/promotion-strategy.md
+++ b/docs/promotion-strategy.md
@@ -1,0 +1,121 @@
+# Promotion Strategy: Three-Repo Dev → Test → Prod
+
+**Purpose**: Team discussion document — how we stage, validate, and promote workflow conventions across projects.
+
+---
+
+## The Three Repos
+
+| Repo | Purpose | Who Uses It | Stability |
+|------|---------|-------------|-----------|
+| `azlan-workflow-dev` | Iterate freely. Break things. | Developers | Unstable — changes daily |
+| `azlan-workflow-test` | SME validation. Acceptance testing. | SMEs + testers | Stable — changes per sprint |
+| `azlan-workflow-prod` | Source of truth. Feeds all live repos. | All projects | Locked — changes per release |
+
+Each repo is a **complete, working instance** of the workflow package — templates, workflows, scripts, plugin. A colleague can bootstrap a sandbox from any of the three to test at that maturity level.
+
+---
+
+## Why Three Repos, Not Three Branches
+
+| Concern | Branch-based | Three repos |
+|---------|-------------|-------------|
+| **Blast radius** | One bad merge to `main` breaks every prod repo | Prod repo is untouched until explicit promotion |
+| **Access control** | Branch protection is all-or-nothing per repo | Separate repo permissions: devs write to dev, only leads write to prod |
+| **Independent testing** | Test branch shares CI config with dev | Test repo has its own Actions, its own webhook secrets, its own project board |
+| **Rollback** | Revert commits on a shared branch — messy history | Point prod consumers back to previous prod tag — clean |
+| **Audit trail** | PR history mixed across environments | Each repo has isolated, reviewable history per environment |
+| **Parallel work** | Feature branches compete on one repo | Dev repo absorbs churn; test and prod stay quiet |
+| **CI/CD isolation** | All environments share one Actions quota and secrets | Each repo has its own secrets, runners, and rate limits |
+| **Repo-level hooks** | Webhooks fire for all environments | Prod repo can notify Slack on release; dev repo stays silent |
+
+**The core argument**: branches share everything (secrets, Actions config, webhooks, permissions, CI quota). Repos share nothing. For a workflow package that gets pushed to live projects, isolation is a feature, not overhead.
+
+---
+
+## How Promotion Works
+
+```
+azlan-workflow-dev          azlan-workflow-test          azlan-workflow-prod
+       │                           │                            │
+  Developer pushes            SME validates               Owner approves
+  freely here                 here                        release here
+       │                           │                            │
+       └──── promote ─────────────►│                            │
+              (PR + CI gate)       └──── promote ──────────────►│
+                                          (PR + SME approval)   │
+                                                                ▼
+                                                     All registered live repos
+                                                     (Azlan-EA-AAA, siblings)
+```
+
+### Promote dev → test
+- **Trigger**: Developer runs `/azlan-github-workflow:promote dev-to-test` or manually creates a PR
+- **What happens**: Script diffs the two repos, opens a PR on `azlan-workflow-test` with a changelog
+- **Gate**: CI validates YAML syntax, script `--help` checks, template parsing
+- **Who merges**: Any team member
+
+### Promote test → prod
+- **Trigger**: Lead runs `/azlan-github-workflow:promote test-to-prod` after SME sign-off
+- **What happens**: Script diffs test vs prod, opens a PR on `azlan-workflow-prod` with full changelog
+- **Gate**: CI validation + mandatory SME approval label + lead approval
+- **Who merges**: Project lead only
+- **On merge**: Semver tag created automatically (v1.0.0, v1.1.0, etc.)
+
+### Sync prod → live repos
+- **Trigger**: New tag on `azlan-workflow-prod`
+- **What happens**: GitHub Action opens PRs on all registered live repos with the updated files
+- **Gate**: Each live repo reviews and merges its own PR (repos control their own pace)
+- **Drift detection**: Weekly scheduled Action compares live repos against prod and flags divergence
+
+---
+
+## What Gets Promoted
+
+Only the convention files cross repo boundaries — never application code:
+
+```
+.github/ISSUE_TEMPLATE/*           ← issue forms
+.github/pull_request_template.md   ← PR template
+.github/labels.yml                 ← label definitions
+.github/workflows/enforce-*.yml    ← enforcement workflows
+.github/workflows/validate-*.yml   ← validation workflows
+scripts/*.sh                       ← setup and migration scripts
+azlan-github-workflow/             ← Claude Code plugin (optional)
+```
+
+---
+
+## Version Pinning
+
+Live repos don't auto-update. Each repo's `azlan-workflow-version` file pins to a prod tag:
+
+```
+v1.2.0
+```
+
+The sync workflow respects this pin. A repo on `v1.1.0` won't receive `v1.2.0` changes until it updates its pin. This lets teams upgrade on their own schedule.
+
+---
+
+## Setup Cost
+
+| Item | One-time effort |
+|------|----------------|
+| Create `azlan-workflow-dev` | `bootstrap-new-repo.sh azlan-workflow-dev` |
+| Create `azlan-workflow-test` | `bootstrap-new-repo.sh azlan-workflow-test` |
+| Create `azlan-workflow-prod` | `bootstrap-new-repo.sh azlan-workflow-prod` |
+| Promotion workflow | One reusable Action (~100 lines) |
+| Sync workflow | One reusable Action (~80 lines) |
+| Drift detection | One scheduled Action (~50 lines) |
+| Promote plugin skills | Two SKILL.md files |
+
+Total: half a day to build. After that, promotion is a one-command operation.
+
+---
+
+## Decision Required
+
+1. **Do we version-pin live repos** or auto-sync on every prod release?
+2. **Who has write access to prod repo** — lead only, or any approver?
+3. **Do we need drift detection** or trust that teams won't edit convention files locally?

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -1,0 +1,185 @@
+# Publishing Guide: Making the Workflow Available Without Repo Access
+
+**Problem**: The bootstrap one-liner fetches scripts and assets from `Azlan-EA-AAA` via the GitHub API. Users need read access to that repo. If you want external collaborators (or future public users) to bootstrap repos without giving them access to `Azlan-EA-AAA`, you need a **public distribution repo**.
+
+---
+
+## Architecture
+
+```
+Azlan-EA-AAA (private / limited access)
+    │
+    │  manual publish (scripts/publish-workflow.sh)
+    │
+    ▼
+ajrmooreuk/azlan-github-workflow (public)
+    │
+    │  users run bootstrap one-liner from here
+    │
+    ▼
+user's new repo (fully configured)
+```
+
+- `Azlan-EA-AAA` remains your private working repo with ontologies, visualiser, and IP
+- `azlan-github-workflow` is a **public read-only mirror** of just the workflow assets
+- External users never need access to `Azlan-EA-AAA`
+
+---
+
+## What Gets Published
+
+Only convention and tooling files cross into the public repo — never ontologies, visualiser code, or proprietary content:
+
+```
+azlan-github-workflow/          (public repo root)
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── epic.yml
+│   │   ├── feature.yml
+│   │   ├── story.yml
+│   │   ├── pbs.yml
+│   │   ├── wbs.yml
+│   │   └── config.yml
+│   ├── pull_request_template.md
+│   ├── labels.yml
+│   └── workflows/
+│       ├── enforce-registry-link.yml
+│       ├── validate-issue-naming.yml
+│       └── validate-labels.yml
+├── scripts/
+│   ├── setup-labels.sh
+│   ├── setup-branch-protection.sh
+│   ├── setup-gh-project.sh
+│   ├── migrate-issues-into-hierarchy.sh
+│   ├── setup-all.sh
+│   └── bootstrap-new-repo.sh
+├── azlan-github-workflow/       ← Claude Code plugin
+│   ├── .claude-plugin/plugin.json
+│   ├── skills/
+│   │   ├── setup-repo/SKILL.md
+│   │   ├── create-epic/SKILL.md
+│   │   ├── create-feature/SKILL.md
+│   │   ├── create-story/SKILL.md
+│   │   ├── setup-project-board/SKILL.md
+│   │   └── review-hierarchy/SKILL.md
+│   ├── docs/
+│   │   ├── onboarding.md
+│   │   ├── quick-reference.md
+│   │   ├── migration-checklist.md
+│   │   └── adr-001-packaging-approach.md
+│   └── README.md
+└── README.md                    ← public-facing quick start
+```
+
+---
+
+## One-Time Setup
+
+### 1. Create the public repo
+
+```bash
+gh repo create azlan-github-workflow --public --clone \
+  --description "Azlan GitHub Workflow — Epic/Feature/Story conventions, templates, and setup scripts"
+```
+
+### 2. Run the publish script
+
+From your local `Azlan-EA-AAA` checkout:
+
+```bash
+./scripts/publish-workflow.sh
+```
+
+This copies all distributable files into the public repo, commits, and pushes.
+
+### 3. Update SOURCE_REPO in the published bootstrap script
+
+The publish script automatically patches `SOURCE_REPO` in the published copy of `bootstrap-new-repo.sh` so it points to the public repo instead of `Azlan-EA-AAA`.
+
+After publishing, external users run:
+
+```bash
+gh api repos/ajrmooreuk/azlan-github-workflow/contents/scripts/bootstrap-new-repo.sh \
+  -q '.content' | base64 -d | bash -s --
+```
+
+No access to `Azlan-EA-AAA` needed.
+
+---
+
+## Publishing Workflow (Ongoing)
+
+When you've made changes in `Azlan-EA-AAA` that you want to release to the public:
+
+### Step 1 — Review what changed
+
+```bash
+# From Azlan-EA-AAA root
+git log --oneline --since="last publish date" -- \
+  .github/ scripts/ azlan-github-workflow/
+```
+
+### Step 2 — Run the publish script
+
+```bash
+./scripts/publish-workflow.sh
+```
+
+The script will:
+
+1. Verify the public repo exists and is cloned locally (sibling directory)
+2. Copy all distributable files from `Azlan-EA-AAA` to the public repo
+3. Patch `SOURCE_REPO` in `bootstrap-new-repo.sh` to point to the public repo
+4. Show a diff of what changed
+5. Prompt for a commit message
+6. Commit and push
+
+### Step 3 — Verify
+
+```bash
+# Quick smoke test from the public repo
+gh api repos/ajrmooreuk/azlan-github-workflow/contents/scripts/bootstrap-new-repo.sh \
+  -q '.content' | base64 -d | bash -s -- publish-verify-test --with-plugin
+
+# Clean up
+gh repo delete ajrmooreuk/publish-verify-test --yes
+```
+
+---
+
+## What NOT to Publish
+
+These files live in `Azlan-EA-AAA` only and must never be copied to the public repo:
+
+| Path | Reason |
+|------|--------|
+| `PBS/` | Ontology library — proprietary IP |
+| `PBS/TOOLS/` | Visualiser source code |
+| `docs/` (root-level) | Internal architecture docs |
+| `.claude/` | Project-specific Claude config |
+| `azlan-github-workflow/docs/publishing-guide.md` | This guide (internal process) |
+| `azlan-github-workflow/docs/promotion-strategy.md` | Internal promotion strategy |
+| `azlan-github-workflow/docs/sme-test-guide.md` | Internal testing guide |
+
+The publish script has an explicit allowlist — only listed files are copied, so nothing leaks by accident.
+
+---
+
+## Rollback
+
+If a bad publish goes out:
+
+```bash
+cd /path/to/azlan-github-workflow   # the public repo
+git log --oneline -5                # find the last good commit
+git revert HEAD                     # revert the bad publish
+git push
+```
+
+---
+
+## Future: Automating the Publish
+
+When the publish cadence justifies it, you can replace the manual script with a GitHub Action on `Azlan-EA-AAA` that auto-publishes on tagged releases. See [promotion-strategy.md](promotion-strategy.md) for the full three-repo approach.
+
+For now, the manual process gives you full control over what goes public and when.

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -1,0 +1,106 @@
+# Azlan Workflow — Quick Reference Card
+
+## Naming Conventions
+
+```
+Epic N: <customer outcome>          → type:epic
+  FN.x: <capability>               → type:feature
+    SN.x.y: <user action>          → type:story
+      [PBS] <deliverable>           → type:pbs
+        [WBS] <work package>        → type:wbs
+```
+
+**Sub-epic suffix**: `Epic 9K:` → `F9K.1:` → `S9K.1.1:`
+
+## Required Labels
+
+| Issue Type | Required Label | Optional |
+|-----------|---------------|----------|
+| Epic | `type:epic` | project label, `domain:*` |
+| Feature | `type:feature` | project label |
+| Story | `type:story` | `tier:*`, `phase:*` |
+| PBS | `type:pbs` | — |
+| WBS | `type:wbs` | — |
+
+## Label Colors
+
+| Category | Color | Labels |
+|----------|-------|--------|
+| Type | `#BFD4F2` | `type:epic`, `type:feature`, `type:story`, `type:pbs`, `type:wbs`, `type:registry` |
+| Domain | `#D4C5F9` | `domain:pf-core`, `domain:baiv`, `domain:w4m`, `domain:air` |
+| Tier | `#FBCA04` | `tier:t1`, `tier:t2`, `tier:t3` |
+| Phase | `#C2E0C6` | `phase:0` through `phase:5` |
+
+## PR Template Fields
+
+```
+## Summary         ← what changed and why
+## Links           ← Resolves: #N, Parent: #N
+## Registry Artifact ← required for WBS/PBS PRs
+## Changes         ← bullet list
+## Test Plan       ← checklist
+## Checklist       ← conventions, secrets, title
+```
+
+## Project Board Fields
+
+| Field | Type | Values |
+|-------|------|--------|
+| Type | Select | Epic, Feature, Story, PBS, WBS, Registry |
+| Status | Select | Backlog, Ready, In Progress, In Review, Done |
+| Priority | Select | P0, P1, P2, P3 |
+| Estimate | Number | — |
+| Registry ID | Text | `namespace:type:name:version` |
+| PBS ID | Text | `PBS-X.Y` |
+| WBS Code | Text | `X.Y.Z` |
+
+## Common gh Commands
+
+```bash
+# Create an epic
+gh issue create --label "type:epic" --title "Epic N: Title"
+
+# Create a feature under epic
+gh issue create --label "type:feature" --title "FN.x: Title"
+
+# List all epics
+gh issue list --label "type:epic"
+
+# List features under epic 10
+gh issue list --json title --jq '.[].title' | grep "^F10\."
+
+# Add issue to project board
+gh project item-add NUMBER --owner OWNER --url ISSUE_URL
+```
+
+## Plugin Skills (Claude Code)
+
+```
+/azlan-github-workflow:setup-repo        owner/repo [--mode solo|team]
+/azlan-github-workflow:create-epic       [title]
+/azlan-github-workflow:create-feature    [title] [--epic N]
+/azlan-github-workflow:create-story      [title] [--feature FN.x]
+/azlan-github-workflow:setup-project-board [title] [--owner login]
+/azlan-github-workflow:review-hierarchy  [owner/repo]
+```
+
+## Bootstrap (New Repo)
+
+```bash
+# Interactive (run in terminal — requires TTY)
+gh api repos/ajrmooreuk/Azlan-EA-AAA/contents/scripts/bootstrap-new-repo.sh \
+  -q '.content' | base64 -d | bash -s --
+
+# Non-interactive (works anywhere — CI, scripts, tool runners)
+... | bash -s -- my-repo [--private] [--mode team] [--with-plugin] [--project-title "Name"]
+```
+
+## Setup Scripts
+
+```bash
+./scripts/setup-labels.sh           [--repo owner/repo]
+./scripts/setup-branch-protection.sh [--repo owner/repo] [--mode solo|team]
+./scripts/setup-gh-project.sh       --owner login --project-title name [--repo owner/repo]
+./scripts/migrate-issues-into-hierarchy.sh --repo owner/repo [--dry-run]
+./scripts/setup-all.sh              --repo owner/repo --owner login --project-title name [--mode solo|team]
+```

--- a/docs/sme-test-guide.md
+++ b/docs/sme-test-guide.md
@@ -1,0 +1,223 @@
+# SME Test Guide — Azlan GitHub Workflow
+
+A step-by-step guide for testing the Azlan workflow package on a fresh repository.
+No prior Git or command-line experience required.
+
+---
+
+## Before You Start
+
+You need these tools installed. If any are missing, follow the links.
+
+| Tool | What It Does | Install |
+|------|-------------|---------|
+| **GitHub account** | Hosts your code and issues | [github.com/signup](https://github.com/signup) |
+| **GitHub CLI (`gh`)** | Lets you run GitHub commands from Terminal | [cli.github.com](https://cli.github.com/) |
+| **Claude Code** (Stage 2 only) | AI coding assistant with plugin support | [claude.com/claude-code](https://claude.com/claude-code) |
+
+### One-time setup: authenticate GitHub CLI
+
+Open **Terminal** (Mac: Spotlight → type "Terminal" → Enter) and paste:
+
+```
+gh auth login
+```
+
+Follow the prompts:
+1. Choose **GitHub.com**
+2. Choose **HTTPS**
+3. Choose **Login with a web browser**
+4. Copy the one-time code, press Enter, paste it in the browser, and authorise
+
+You only need to do this once.
+
+---
+
+## Stage 1: Automated Repo Setup (one command)
+
+This creates a test repository with everything pre-configured — issue templates, labels, branch protection, project board, enforcement workflows, and setup scripts.
+
+### The Command
+
+Open Terminal and paste this single command:
+
+```
+gh api repos/ajrmooreuk/Azlan-EA-AAA/contents/scripts/bootstrap-new-repo.sh -q '.content' | base64 -d | bash -s -- my-workflow-test
+```
+
+That's it. Sit back and watch it run.
+
+**What it does automatically (in order):**
+
+| Step | What Happens | Time |
+|------|-------------|------|
+| 1 | Creates a new public GitHub repo called `my-workflow-test` | ~3s |
+| 2 | Downloads all issue templates (Epic, Feature, Story, PBS, WBS) | ~5s |
+| 3 | Downloads setup scripts and enforcement workflows | ~3s |
+| 4 | Commits and pushes everything to the repo | ~3s |
+| 5 | Creates 21 standard labels (type, domain, tier, phase) | ~15s |
+| 6 | Configures branch protection on `main` | ~2s |
+| 7 | Creates a project board with 7 standard fields | ~5s |
+
+**Total: about 30 seconds.**
+
+When it finishes, you'll see a summary with links to your new repo.
+
+### Options
+
+If you need different settings, add flags:
+
+```
+# Shorthand for the one-liner (used in examples below)
+# BOOTSTRAP = gh api repos/ajrmooreuk/Azlan-EA-AAA/contents/scripts/bootstrap-new-repo.sh -q '.content' | base64 -d | bash -s --
+
+# Private repo with team-level branch protection
+BOOTSTRAP my-workflow-test --private --mode team
+
+# Include the Claude Code plugin (for Stage 2)
+BOOTSTRAP my-workflow-test --with-plugin
+
+# Custom project board name
+BOOTSTRAP my-workflow-test --project-title "Sprint Board"
+
+# All options at once
+BOOTSTRAP my-workflow-test --private --mode team --with-plugin --project-title "My Project"
+```
+
+To run any of these for real, replace `BOOTSTRAP` with the full command from "The Command" above.
+
+### If you prefer to run it locally
+
+```
+cd /path/to/Azlan-EA-AAA
+./scripts/bootstrap-new-repo.sh my-workflow-test
+```
+
+### Verify It Worked
+
+Open these links in your browser (replace `YOUR_USERNAME` with your GitHub username):
+
+1. **Issue templates**: `https://github.com/YOUR_USERNAME/my-workflow-test/issues/new/choose`
+   - You should see 5 issue types: Epic, Feature, Story, PBS Component, WBS Task
+
+2. **Labels**: `https://github.com/YOUR_USERNAME/my-workflow-test/labels`
+   - You should see 21+ labels in colour-coded groups
+
+3. **Workflows**: `https://github.com/YOUR_USERNAME/my-workflow-test/actions`
+   - You should see 3 enforcement workflows
+
+4. **Project board**: `https://github.com/users/YOUR_USERNAME/projects/`
+   - Click your project → you should see 7 fields (Type, Status, Priority, Estimate, Registry ID, PBS ID, WBS Code)
+
+### Test the Issue Templates
+
+| Test | How | Expected Result |
+|------|-----|-----------------|
+| **Create an Epic** | Issue chooser → Epic → title: `Epic 1: Test Workflow` → Submit | Created with `type:epic` label |
+| **Create a Feature** | Issue chooser → Feature → title: `F1.1: Test Feature` → Parent Epic: `#1` → Submit | Created with `type:feature` label |
+| **Create a Story** | Issue chooser → Story → title: `S1.1.1: Test Story` → Parent Feature: `#2` → Submit | Created with `type:story` label |
+
+### Stage 1 Checklist
+
+- [ ] Bootstrap script ran without errors
+- [ ] 5 issue templates appear on the chooser page
+- [ ] 21+ labels exist with correct colours
+- [ ] 3 enforcement workflows appear in Actions tab
+- [ ] Project board has 7 custom fields
+- [ ] Test epic, feature, and story created with correct labels
+
+---
+
+## Stage 2: Claude Code Plugin (one command)
+
+This adds intelligent, convention-aware commands to Claude Code.
+
+### Setup
+
+If you didn't use `--with-plugin` in Stage 1, run the bootstrap again with the flag:
+
+```
+cd my-workflow-test
+gh api repos/ajrmooreuk/Azlan-EA-AAA/contents/scripts/bootstrap-new-repo.sh -q '.content' | base64 -d | bash -s -- my-workflow-test --with-plugin
+```
+
+Or if you already ran Stage 1, just add the plugin:
+
+```
+cd my-workflow-test
+mkdir -p azlan-github-workflow/.claude-plugin
+mkdir -p azlan-github-workflow/skills/{setup-repo,create-epic,create-feature,create-story,setup-project-board,review-hierarchy}
+
+gh api repos/ajrmooreuk/Azlan-EA-AAA/contents/azlan-github-workflow/.claude-plugin/plugin.json?ref=main -q '.content' | base64 -d > azlan-github-workflow/.claude-plugin/plugin.json
+
+for skill in setup-repo create-epic create-feature create-story setup-project-board review-hierarchy; do
+  gh api "repos/ajrmooreuk/Azlan-EA-AAA/contents/azlan-github-workflow/skills/$skill/SKILL.md?ref=main" -q '.content' | base64 -d > "azlan-github-workflow/skills/$skill/SKILL.md"
+done
+```
+
+### Launch Claude Code with the plugin
+
+```
+claude --plugin-dir ./azlan-github-workflow
+```
+
+Claude Code opens. You should see the 6 Azlan skills available.
+
+### Test the Plugin Skills
+
+Type each command at the Claude Code prompt:
+
+| Test | Command | Expected Result |
+|------|---------|-----------------|
+| **Audit** | `/azlan-github-workflow:review-hierarchy YOUR_USERNAME/my-workflow-test` | Compliance report — your test issues from Stage 1 should pass |
+| **Create Epic** | `/azlan-github-workflow:create-epic Automated Test Epic` | Creates `Epic 2: Automated Test Epic` (auto-detects next number) |
+| **Create Feature** | `/azlan-github-workflow:create-feature Plugin Feature --epic 2` | Creates `F2.1: Plugin Feature` linked to Epic 2 |
+| **Create Story** | `/azlan-github-workflow:create-story Plugin Story --feature F2.1` | Creates `S2.1.1: Plugin Story` linked to F2.1 |
+
+### Stage 2 Checklist
+
+- [ ] Claude Code launched with 6 skills visible
+- [ ] `review-hierarchy` produced a compliance report
+- [ ] `create-epic` auto-numbered correctly (Epic 2)
+- [ ] `create-feature` linked to parent epic
+- [ ] `create-story` linked to parent feature
+- [ ] All issues have correct titles, labels, and body content
+
+---
+
+## Cleanup
+
+When you're done testing, delete the test repo:
+
+```
+gh repo delete YOUR_USERNAME/my-workflow-test --yes
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `gh: command not found` | Install GitHub CLI: [cli.github.com](https://cli.github.com/) |
+| `not logged in` or `401` | Run `gh auth login` and re-authenticate |
+| `permission denied` on scripts | Run `chmod +x scripts/*.sh` |
+| `claude: command not found` | Install Claude Code: [claude.com/claude-code](https://claude.com/claude-code) |
+| Labels already exist errors | Safe to ignore — the script skips existing labels |
+| Issue templates not showing | Wait 30 seconds and refresh — GitHub caches template lists |
+| Bootstrap says repo exists | Safe — it will re-use the existing repo |
+| `base64: invalid input` | Check your internet connection and try again |
+
+---
+
+## Naming Convention Cheatsheet
+
+```
+Epic 1: Customer Outcome          → type:epic
+  F1.1: Feature Capability        → type:feature
+    S1.1.1: User Story            → type:story
+      [PBS] Deliverable           → type:pbs
+        [WBS] Work Package        → type:wbs
+```
+
+Each level links to its parent. Labels are applied automatically by the templates.


### PR DESCRIPTION
## Summary
- Copies `docs/` folder from `Azlan-EA-AAA/azlan-github-workflow/docs`
- Includes 7 reference documents: onboarding, publishing guide, migration checklist, promotion strategy, quick reference, SME test guide, and ADR-001

## Test plan
- [ ] Verify all 7 markdown files render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)